### PR TITLE
feat(services,server-spi-private): Attaching impersonator details to UserSession notes

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/broker/provider/IdentityProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/broker/provider/IdentityProvider.java
@@ -37,6 +37,9 @@ public interface IdentityProvider<C extends IdentityProviderModel> extends Provi
     String EXTERNAL_IDENTITY_PROVIDER = "EXTERNAL_IDENTITY_PROVIDER";
     String FEDERATED_ACCESS_TOKEN = "FEDERATED_ACCESS_TOKEN";
 
+    String REMOTE_USERNAME = "remote_username";
+    String REMOTE_ID = "remote_id";
+
     interface AuthenticationCallback {
         /**
          * This method should be called by provider after the JAXRS callback endpoint has finished authentication

--- a/server-spi-private/src/main/java/org/keycloak/models/ImpersonationConstants.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/ImpersonationConstants.java
@@ -27,6 +27,12 @@ import org.keycloak.models.utils.KeycloakModelUtils;
 public class ImpersonationConstants {
     public static String IMPERSONATION_ROLE = "impersonation";
 
+    public enum SessionNote {
+        IMPERSONATOR_ID,
+        IMPERSONATOR_USERNAME,
+        IMPERSONATOR_REMOTE_ID,
+        IMPERSONATOR_REMOTE_USERNAME,
+    }
 
     public static void setupMasterRealmRole(RealmProvider model, RealmModel realm) {
         RealmModel adminRealm;


### PR DESCRIPTION
Feels a little hacky and incomplete, but gets the job done for now. Not sure how to write tests for this stuff either, probably because it's a bit of a hack.

According to comments on https://github.com/keycloak/keycloak/pull/3788 and https://github.com/keycloak/keycloak/pull/4813 the maintainers would prefer this be stored in the `UserSessionModel`, but I don't have time to do that right now.